### PR TITLE
Allow escaping by using a backslash

### DIFF
--- a/tagparser.go
+++ b/tagparser.go
@@ -67,6 +67,12 @@ func (p *tagParser) parseKey() {
 		case '\'':
 			p.parseQuotedValue()
 			return
+                case '\\':
+                        if p.Valid() {
+                                c := p.Read()
+                                b = append(b, c)
+                        }
+                        continue
 		default:
 			b = append(b, c)
 		}

--- a/tagparser_test.go
+++ b/tagparser_test.go
@@ -20,6 +20,7 @@ var tagTests = []struct {
 	{",hello,world", "", map[string]string{"hello": "", "world": ""}},
 	{"hello:", "", map[string]string{"hello": ""}},
 	{"hello:world", "", map[string]string{"hello": "world"}},
+        {"hello\\:world", "hello:world", nil},
 	{"hello:world,foo", "", map[string]string{"hello": "world", "foo": ""}},
 	{"hello:world,foo:bar", "", map[string]string{"hello": "world", "foo": "bar"}},
 	{"hello:'world1,world2'", "", map[string]string{"hello": "'world1,world2'"}},


### PR DESCRIPTION
Make it possible for msgpack to use keys with a colon, for example:
```go
struct Msg {
        ProjectID   uint            `json:"project:id,omitempty" msgpack:"project\\:id,omitempty"` 
        UserID      uint            `json:"user:id,omitempty" msgpack:"user\\:id,omitempty"`
}
```